### PR TITLE
Add registry entry template

### DIFF
--- a/MHFConnector.reg
+++ b/MHFConnector.reg
@@ -1,0 +1,4 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\Software\Wow6432Node\CAPCOM\Monster Hunter Frontier Online]
+"ExecPath"="C:\\YOUR\\MHF\\PATH\\mhf.exe"


### PR DESCRIPTION
Since the form is hardcoded to read from a registry key, the repo should include at least a template to add such a key without having to use a relevant installer.